### PR TITLE
feat(cache): add Redis distributed cache for book reads

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,14 +3,20 @@ WORKDIR /src
 
 COPY BookVerseApi.sln ./
 
-# 🔥 IMPORTANT: keep real folder structure
-COPY src/ ./src/
-COPY tests/ ./tests/
+COPY src/BookVerse.Core/*.csproj src/BookVerse.Core/
+COPY src/BookVerse.Application/*.csproj src/BookVerse.Application/
+COPY src/BookVerse.Infrastructure/*.csproj src/BookVerse.Infrastructure/
+COPY src/BookVerse.Api/*.csproj src/BookVerse.Api/
+
+COPY tests/BookVerse.Tests/*.csproj tests/BookVerse.Tests/
 
 RUN dotnet restore BookVerseApi.sln
 
+COPY . .
+
 WORKDIR /src/src/BookVerse.Api
 RUN dotnet build BookVerse.Api.csproj -c Release -o /app/build --no-restore
+
 
 FROM build AS publish
 RUN dotnet publish BookVerse.Api.csproj -c Release -o /app/publish \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,12 +5,14 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    image: bookverse-api:${IMAGE_TAG}  
     container_name: bookverse-api
     ports:
       - "5000:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=BookVerseDb;Username=postgres;Password=${POSTGRES_PASSWORD}
+      - ConnectionStrings__Redis=redis:6379
       - JwtOptions__Secret=${JWT_SECRET}
       - JwtOptions__Issuer=${JWT_ISSUER}
       - JwtOptions__Audience=${JWT_AUDIENCE}
@@ -31,9 +33,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -51,12 +55,27 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d BookVerseDb"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d BookVerseDb" ]
       interval: 10s
       timeout: 5s
       retries: 10
       start_period: 20s
     restart: unless-stopped
+  redis:
+    image: redis:7-alpine
+    container_name: bookverse-redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: [ "CMD","redis-cli","ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
 
 volumes:
   pgdata:
+  redisdata:

--- a/src/BookVerse.Api/Program.cs
+++ b/src/BookVerse.Api/Program.cs
@@ -102,6 +102,13 @@ builder.Services.AddRateLimiter(options =>
 });
 builder.Services.AddResponseCaching();
 builder.Services.AddMemoryCache();
+
+// Redis distributed cache
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = builder.Configuration.GetConnectionString("Redis");
+    options.InstanceName = "BookVerse";
+});
 builder.Services.AddApiVersioning(options =>
 {
     options.DefaultApiVersion = new ApiVersion(1, 0);
@@ -303,7 +310,7 @@ builder.Services.AddScoped<IPaymentService, PaymentService>();
 builder.Services.AddTransient<IStripePaymentIntentService, StripePaymentIntentService>();
 builder.Services.AddTransient<PaymentIntentService>();
 builder.Services.AddTransient<IStripeWebhookConstructor, StripeWebhookConstructor>();
-
+builder.Services.AddSingleton<ICacheService, RedisCacheService>();
 builder.Services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
 
 // Token Processing

--- a/src/BookVerse.Application/Interfaces/ICacheService.cs
+++ b/src/BookVerse.Application/Interfaces/ICacheService.cs
@@ -1,0 +1,12 @@
+﻿namespace BookVerse.Application.Interfaces;
+
+public interface ICacheService
+{
+    Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class;
+
+    Task SetAsync<T>(string key, T value, TimeSpan? expiry = null, CancellationToken cancellationToken = default)
+        where T : class;
+
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+    Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
+}

--- a/src/BookVerse.Core/Constants/CacheKeys.cs
+++ b/src/BookVerse.Core/Constants/CacheKeys.cs
@@ -1,0 +1,10 @@
+﻿namespace BookVerse.Core.Constants;
+
+public static class CacheKeys
+{
+    public static string Book(int id) => $"book:{id}";
+    public const string BooksPagePrefix = "books:page:";
+
+    public static string BooksPage(int page, int size, string? search, string? sort)
+        => $"{BooksPagePrefix}{page}:{size}:{search ?? "none"}:{sort ?? "none"}";
+}

--- a/src/BookVerse.Infrastructure/BookVerse.Infrastructure.csproj
+++ b/src/BookVerse.Infrastructure/BookVerse.Infrastructure.csproj
@@ -22,10 +22,8 @@
         <PackageReference Include="Stripe.net" Version="47.4.0"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
         <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Data\Migrations\" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0"/>
     </ItemGroup>
 
 

--- a/src/BookVerse.Infrastructure/Services/BooksService.cs
+++ b/src/BookVerse.Infrastructure/Services/BooksService.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using BookVerse.Application.Dtos.Book;
 using BookVerse.Application.Interfaces;
+using BookVerse.Core.Constants;
 using BookVerse.Core.Entities;
 using BookVerse.Core.Exceptions;
 using BookVerse.Core.Models;
@@ -11,14 +12,16 @@ namespace BookVerse.Infrastructure.Services;
 public class BooksService : IBooksService
 {
     private readonly ILogger<BooksService> _logger;
+    private readonly ICacheService _cache;
     private readonly IMapper _mapper;
     private readonly IUnitOfWork _unitOfWork;
 
-    public BooksService(IUnitOfWork unitOfWork, IMapper mapper, ILogger<BooksService> logger)
+    public BooksService(IUnitOfWork unitOfWork, IMapper mapper, ILogger<BooksService> logger, ICacheService cache)
     {
         _unitOfWork = unitOfWork;
         _mapper = mapper;
         _logger = logger;
+        _cache = cache;
     }
 
     public async Task<PagedResult<BookReadDto>> GetPagedAsync(BookQueryParameters parameters,
@@ -37,6 +40,13 @@ public class BooksService : IBooksService
 
     public async Task<BookReadDto?> GetByIdAsync(int id, CancellationToken cancellationToken)
     {
+        var cacheKey = CacheKeys.Book(id);
+        // trying redis first
+        var cached = await _cache.GetAsync<BookReadDto>(cacheKey, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        // cache miss - retrieving from database
         var book = await _unitOfWork.Books.GetByIdWithDetailsAsync(id, cancellationToken);
 
         if (book == null)
@@ -45,7 +55,10 @@ public class BooksService : IBooksService
             return null;
         }
 
-        return _mapper.Map<BookReadDto>(book);
+        var dto = _mapper.Map<BookReadDto>(book);
+        // Store in Redis for 5 minutes
+        await _cache.SetAsync(cacheKey, dto, TimeSpan.FromMinutes(5), cancellationToken);
+        return dto;
     }
 
     public async Task<BookReadDto> CreateAsync(BookCreateDto bookDto, CancellationToken cancellationToken)
@@ -195,7 +208,10 @@ public class BooksService : IBooksService
 
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         await _unitOfWork.CommitTransactionAsync();
-
+        
+        //Invalidate cache after update
+        await _cache.RemoveAsync(CacheKeys.Book(id), cancellationToken);
+        
         _logger.LogInformation("Updated book: {BookId}", id);
         return true;
     }
@@ -212,6 +228,10 @@ public class BooksService : IBooksService
 
         _unitOfWork.Books.Delete(book);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
+        
+        // Invalidate cache so stale data is not retrieved.
+        await _cache.RemoveAsync(CacheKeys.Book(id), cancellationToken);
+        
         _logger.LogInformation("Deleted book: {BookId}", id);
         return true;
     }

--- a/src/BookVerse.Infrastructure/Services/RedisCacheService.cs
+++ b/src/BookVerse.Infrastructure/Services/RedisCacheService.cs
@@ -1,0 +1,87 @@
+﻿using System.Text.Json;
+using BookVerse.Application.Interfaces;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace BookVerse.Infrastructure.Services;
+
+public class RedisCacheService : ICacheService
+{
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<RedisCacheService> _logger;
+
+    private static readonly TimeSpan DefaultExpiry = TimeSpan.FromMinutes(5);
+
+    private static readonly JsonSerializerOptions JsonOptions = new
+        ()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+    public RedisCacheService(IDistributedCache cache, ILogger<RedisCacheService> logger)
+    {
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var data = await _cache.GetStringAsync(key, cancellationToken);
+
+            if (data is null)
+            {
+                _logger.LogDebug("Cache miss for key: {Key}", key);
+                return null;
+            }
+
+            _logger.LogDebug("Cache hit for key: {Key}", key);
+            return JsonSerializer.Deserialize<T>(data, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Redis GET failed for key {Key}. Falling back to database.", key);
+            return null;
+        }
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan? expiry = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        try
+        {
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = expiry ?? DefaultExpiry
+            };
+
+            var data = JsonSerializer.Serialize(value, JsonOptions);
+            await _cache.SetStringAsync(key, data, options, cancellationToken);
+            _logger.LogDebug("Cache SET for key: {Key} (expires in {Expiry})", key, expiry ?? DefaultExpiry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Redis SET failed for key {Key}. Continuing without cache.", key);
+        }
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _cache.RemoveAsync(key, cancellationToken);
+            _logger.LogDebug("Cache REMOVE for key: {Key}", key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Redis REMOVE failed for key {Key}.", key);
+        }
+    }
+
+    public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+    {
+        await RemoveAsync(prefix, cancellationToken);
+    }
+}

--- a/tests/BookVerse.Tests/Unit/Services/BooksServiceTests.cs
+++ b/tests/BookVerse.Tests/Unit/Services/BooksServiceTests.cs
@@ -18,6 +18,7 @@ public class BooksServiceTests
     private readonly Mock<ICategoryRepository> _mockCategoryRepository;
     private readonly Mock<IMapper> _mockMapper;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly Mock<ICacheService> _mockCache;
     private readonly BooksService _sut;
 
     public BooksServiceTests()
@@ -27,6 +28,7 @@ public class BooksServiceTests
         _mockCategoryRepository = new Mock<ICategoryRepository>();
         _mockMapper = new Mock<IMapper>();
         _mockUnitOfWork = new Mock<IUnitOfWork>();
+        _mockCache = new Mock<ICacheService>();
         var mockLogger = new Mock<ILogger<BooksService>>();
 
         _mockUnitOfWork.Setup(x => x.Books).Returns(_mockBookRepository.Object);
@@ -39,7 +41,7 @@ public class BooksServiceTests
         _mockUnitOfWork.Setup(x => x.RollbackTransactionAsync()).Returns(Task.CompletedTask);
         _mockUnitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
-        _sut = new BooksService(_mockUnitOfWork.Object, _mockMapper.Object, mockLogger.Object);
+        _sut = new BooksService(_mockUnitOfWork.Object, _mockMapper.Object, mockLogger.Object, _mockCache.Object);
     }
 
     // -------------------------------------------------------------------------
@@ -53,12 +55,19 @@ public class BooksServiceTests
         var book = new Book { Id = 1, Title = "Clean Code" };
         var expectedDto = new BookReadDto { Id = 1, Title = "Clean Code" };
 
+        _mockCache.Setup(x => x.GetAsync<BookReadDto>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BookReadDto?)null); // force cache miss
+
         _mockBookRepository
             .Setup(x => x.GetByIdWithDetailsAsync(book.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(book);
         _mockMapper
             .Setup(x => x.Map<BookReadDto>(book))
             .Returns(expectedDto);
+
+        _mockCache.Setup(x => x.SetAsync(
+            It.IsAny<string>(),
+            expectedDto, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         // Act
         var result = await _sut.GetByIdAsync(book.Id, CancellationToken.None);
@@ -67,12 +76,24 @@ public class BooksServiceTests
         result.Should().NotBeNull();
         result!.Id.Should().Be(book.Id);
         result.Title.Should().Be(book.Title);
+
+        _mockCache.Verify(x =>
+                x.SetAsync(
+                    It.IsAny<string>(),
+                    expectedDto,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
     public async Task GetByIdAsync_WhenBookDoesNotExist_ReturnsNull()
     {
         // Arrange
+
+        _mockCache.Setup(x => x.GetAsync<BookReadDto>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BookReadDto?)null);
+
         _mockBookRepository
             .Setup(x => x.GetByIdWithDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Book?)null);
@@ -82,6 +103,14 @@ public class BooksServiceTests
 
         // Assert
         result.Should().BeNull();
+
+        _mockCache.Verify(x =>
+                x.SetAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<BookReadDto>(),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()),
+            times: Times.Never);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
- Add ICacheService interface in Application layer
- Implement RedisCacheService wrapping IDistributedCache
- Cache GetByIdAsync results in BooksService (5 min TTL)
- Invalidate cache on book update and delete
- Add CacheKeys constants class for consistent key naming
- Register AddStackExchangeRedisCache in Program.cs
- Add redis:7-alpine service to docker-compose
- Cache failures fall back to database (never breaks the request)